### PR TITLE
Fix for IOS 8.3 to handle changes in how UI_USER_INTERFACE_IDIOM is defined

### DIFF
--- a/StandardPaths/StandardPaths.h
+++ b/StandardPaths/StandardPaths.h
@@ -42,6 +42,7 @@
 #define SP_SWIZZLE_ENABLED 1
 #endif
 
+#ifndef __IPHONE_8_3
 
 #ifndef UI_USER_INTERFACE_IDIOM
 #define UI_USER_INTERFACE_IDIOM() UIUserInterfaceIdiomDesktop
@@ -54,7 +55,11 @@ typedef NS_ENUM(NSInteger, UIUserInterfaceIdiom)
     UIUserInterfaceIdiomDesktop
 };
 
-#elif TARGET_OS_IPHONE
+#endif
+
+#endif
+
+#if TARGET_OS_IPHONE
 
 #define UIUserInterfaceIdiomDesktop (UIUserInterfaceIdiomPad + 1)
 

--- a/StandardPaths/StandardPaths.m
+++ b/StandardPaths/StandardPaths.m
@@ -38,7 +38,7 @@
 
 #pragma GCC diagnostic ignored "-Wgnu"
 #pragma GCC diagnostic ignored "-Wselector"
-
+#pragma GCC diagnostic ignored "-Wswitch"
 
 //workaround for rdar://problem/11017158 crash in iOS5
 extern NSString *const NSURLIsExcludedFromBackupKey __attribute__((weak_import));


### PR DESCRIPTION
Guarded the non IOS definition of UI_USER_INTERFACE_IDIOM for IOS 8_3.
Added -Wswitch to implementation to stop related warnings in the implementation.

The test projects included in StandardPaths run for both IOS and OS X.

Fixes #10 