### PR TITLE
Dynamic Framework project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: objective-c
+os: osx
+osx_image: xcode7.3
+env:
+  matrix:
+    - TEST_TYPE=Framework
+    - TEST_TYPE=CocoaPods
+    - TEST_TYPE=Carthage
+install:
+- |
+  if [ "$TEST_TYPE" = "Framework" ]; then
+    gem install xcpretty -N --no-ri --no-rdoc
+  elif [ "$TEST_TYPE" = Carthage ]; then    
+    brew install carthage || brew upgrade carthage
+  fi
+script:
+- |
+  if [ "$TEST_TYPE" = "Framework" ]; then
+    set -o pipefail
+    xcodebuild build test -project StandardPaths.xcodeproj -scheme StandardPaths -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 4s" | xcpretty -c
+    xcodebuild build -project StandardPaths.xcodeproj -scheme libStandardPaths -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 4s" | xcpretty -c
+    xcodebuild build test -project StandardPaths.xcodeproj -scheme "StandardPaths OSX" | xcpretty -c
+  elif [ "$TEST_TYPE" = CocoaPods ]; then
+    pod lib lint StandardPaths.podspec.json
+    pod lib lint --use-libraries StandardPaths.podspec.json
+  elif [ "$TEST_TYPE" = Carthage ]; then
+    carthage build --no-skip-current
+  fi

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.6.4</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2016 Charcoal Design. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/StandardPaths.xcodeproj/project.pbxproj
+++ b/StandardPaths.xcodeproj/project.pbxproj
@@ -1,0 +1,724 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		46A8ACC71CDF0500009AFA26 /* StandardPaths.h in Headers */ = {isa = PBXBuildFile; fileRef = 46A8ACC61CDF0500009AFA26 /* StandardPaths.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		46A8ACCE1CDF0500009AFA26 /* StandardPaths.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A8ACC31CDF0500009AFA26 /* StandardPaths.framework */; };
+		46A8ACD31CDF0500009AFA26 /* StandardPathsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 46A8ACD21CDF0500009AFA26 /* StandardPathsTests.m */; };
+		46A8ACEC1CDF0522009AFA26 /* StandardPaths.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A8ACE21CDF0522009AFA26 /* StandardPaths.framework */; };
+		46A8ACF91CDF063D009AFA26 /* StandardPathsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 46A8ACD21CDF0500009AFA26 /* StandardPathsTests.m */; };
+		46A8ACFA1CDF0646009AFA26 /* StandardPaths.h in Headers */ = {isa = PBXBuildFile; fileRef = 46A8ACC61CDF0500009AFA26 /* StandardPaths.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		46A8ACFC1CDF079A009AFA26 /* StandardPaths.m in Sources */ = {isa = PBXBuildFile; fileRef = 46A8ACFB1CDF079A009AFA26 /* StandardPaths.m */; };
+		46A8ACFD1CDF079A009AFA26 /* StandardPaths.m in Sources */ = {isa = PBXBuildFile; fileRef = 46A8ACFB1CDF079A009AFA26 /* StandardPaths.m */; };
+		46A8AD0B1CDF09AA009AFA26 /* StandardPaths.m in Sources */ = {isa = PBXBuildFile; fileRef = 46A8ACFB1CDF079A009AFA26 /* StandardPaths.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		46A8ACCF1CDF0500009AFA26 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 46A8ACBA1CDF0500009AFA26 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 46A8ACC21CDF0500009AFA26;
+			remoteInfo = StandardPaths;
+		};
+		46A8ACED1CDF0522009AFA26 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 46A8ACBA1CDF0500009AFA26 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 46A8ACE11CDF0522009AFA26;
+			remoteInfo = "StandardPaths OSX";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		46A8AD001CDF08E8009AFA26 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		46A8ACC31CDF0500009AFA26 /* StandardPaths.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StandardPaths.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		46A8ACC61CDF0500009AFA26 /* StandardPaths.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StandardPaths.h; sourceTree = "<group>"; };
+		46A8ACC81CDF0500009AFA26 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Info.plist; sourceTree = "<group>"; };
+		46A8ACCD1CDF0500009AFA26 /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		46A8ACD21CDF0500009AFA26 /* StandardPathsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StandardPathsTests.m; sourceTree = "<group>"; };
+		46A8ACD41CDF0500009AFA26 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		46A8ACE21CDF0522009AFA26 /* StandardPaths.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StandardPaths.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		46A8ACEB1CDF0522009AFA26 /* UnitTests OSX.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "UnitTests OSX.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		46A8ACFB1CDF079A009AFA26 /* StandardPaths.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StandardPaths.m; sourceTree = "<group>"; };
+		46A8AD021CDF08E8009AFA26 /* libStandardPaths.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libStandardPaths.a; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		46A8ACBF1CDF0500009AFA26 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		46A8ACCA1CDF0500009AFA26 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				46A8ACCE1CDF0500009AFA26 /* StandardPaths.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		46A8ACDE1CDF0522009AFA26 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		46A8ACE81CDF0522009AFA26 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				46A8ACEC1CDF0522009AFA26 /* StandardPaths.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		46A8ACFF1CDF08E8009AFA26 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		46A8ACB91CDF0500009AFA26 = {
+			isa = PBXGroup;
+			children = (
+				46A8ACC51CDF0500009AFA26 /* StandardPaths */,
+				46A8ACD11CDF0500009AFA26 /* UnitTests */,
+				46A8ACC41CDF0500009AFA26 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		46A8ACC41CDF0500009AFA26 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				46A8ACC31CDF0500009AFA26 /* StandardPaths.framework */,
+				46A8ACCD1CDF0500009AFA26 /* UnitTests.xctest */,
+				46A8ACE21CDF0522009AFA26 /* StandardPaths.framework */,
+				46A8ACEB1CDF0522009AFA26 /* UnitTests OSX.xctest */,
+				46A8AD021CDF08E8009AFA26 /* libStandardPaths.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		46A8ACC51CDF0500009AFA26 /* StandardPaths */ = {
+			isa = PBXGroup;
+			children = (
+				46A8ACC61CDF0500009AFA26 /* StandardPaths.h */,
+				46A8ACFB1CDF079A009AFA26 /* StandardPaths.m */,
+				46A8ACC81CDF0500009AFA26 /* Info.plist */,
+			);
+			path = StandardPaths;
+			sourceTree = "<group>";
+		};
+		46A8ACD11CDF0500009AFA26 /* UnitTests */ = {
+			isa = PBXGroup;
+			children = (
+				46A8ACD21CDF0500009AFA26 /* StandardPathsTests.m */,
+				46A8ACD41CDF0500009AFA26 /* Info.plist */,
+			);
+			path = UnitTests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		46A8ACC01CDF0500009AFA26 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				46A8ACC71CDF0500009AFA26 /* StandardPaths.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		46A8ACDF1CDF0522009AFA26 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				46A8ACFA1CDF0646009AFA26 /* StandardPaths.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		46A8ACC21CDF0500009AFA26 /* StandardPaths */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 46A8ACD71CDF0500009AFA26 /* Build configuration list for PBXNativeTarget "StandardPaths" */;
+			buildPhases = (
+				46A8ACBE1CDF0500009AFA26 /* Sources */,
+				46A8ACBF1CDF0500009AFA26 /* Frameworks */,
+				46A8ACC01CDF0500009AFA26 /* Headers */,
+				46A8ACC11CDF0500009AFA26 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = StandardPaths;
+			productName = StandardPaths;
+			productReference = 46A8ACC31CDF0500009AFA26 /* StandardPaths.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		46A8ACCC1CDF0500009AFA26 /* UnitTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 46A8ACDA1CDF0500009AFA26 /* Build configuration list for PBXNativeTarget "UnitTests" */;
+			buildPhases = (
+				46A8ACC91CDF0500009AFA26 /* Sources */,
+				46A8ACCA1CDF0500009AFA26 /* Frameworks */,
+				46A8ACCB1CDF0500009AFA26 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				46A8ACD01CDF0500009AFA26 /* PBXTargetDependency */,
+			);
+			name = UnitTests;
+			productName = StandardPathsTests;
+			productReference = 46A8ACCD1CDF0500009AFA26 /* UnitTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		46A8ACE11CDF0522009AFA26 /* StandardPaths OSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 46A8ACF31CDF0522009AFA26 /* Build configuration list for PBXNativeTarget "StandardPaths OSX" */;
+			buildPhases = (
+				46A8ACDD1CDF0522009AFA26 /* Sources */,
+				46A8ACDE1CDF0522009AFA26 /* Frameworks */,
+				46A8ACDF1CDF0522009AFA26 /* Headers */,
+				46A8ACE01CDF0522009AFA26 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "StandardPaths OSX";
+			productName = "StandardPaths OSX";
+			productReference = 46A8ACE21CDF0522009AFA26 /* StandardPaths.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		46A8ACEA1CDF0522009AFA26 /* UnitTests OSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 46A8ACF61CDF0522009AFA26 /* Build configuration list for PBXNativeTarget "UnitTests OSX" */;
+			buildPhases = (
+				46A8ACE71CDF0522009AFA26 /* Sources */,
+				46A8ACE81CDF0522009AFA26 /* Frameworks */,
+				46A8ACE91CDF0522009AFA26 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				46A8ACEE1CDF0522009AFA26 /* PBXTargetDependency */,
+			);
+			name = "UnitTests OSX";
+			productName = "StandardPaths OSXTests";
+			productReference = 46A8ACEB1CDF0522009AFA26 /* UnitTests OSX.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		46A8AD011CDF08E8009AFA26 /* libStandardPaths */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 46A8AD081CDF08E9009AFA26 /* Build configuration list for PBXNativeTarget "libStandardPaths" */;
+			buildPhases = (
+				46A8ACFE1CDF08E8009AFA26 /* Sources */,
+				46A8ACFF1CDF08E8009AFA26 /* Frameworks */,
+				46A8AD001CDF08E8009AFA26 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = libStandardPaths;
+			productName = libStandardPaths;
+			productReference = 46A8AD021CDF08E8009AFA26 /* libStandardPaths.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		46A8ACBA1CDF0500009AFA26 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0730;
+				ORGANIZATIONNAME = "Charcoal Design";
+				TargetAttributes = {
+					46A8ACC21CDF0500009AFA26 = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+					46A8ACCC1CDF0500009AFA26 = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+					46A8ACE11CDF0522009AFA26 = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+					46A8ACEA1CDF0522009AFA26 = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+					46A8AD011CDF08E8009AFA26 = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+				};
+			};
+			buildConfigurationList = 46A8ACBD1CDF0500009AFA26 /* Build configuration list for PBXProject "StandardPaths" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 46A8ACB91CDF0500009AFA26;
+			productRefGroup = 46A8ACC41CDF0500009AFA26 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				46A8ACC21CDF0500009AFA26 /* StandardPaths */,
+				46A8ACCC1CDF0500009AFA26 /* UnitTests */,
+				46A8ACE11CDF0522009AFA26 /* StandardPaths OSX */,
+				46A8ACEA1CDF0522009AFA26 /* UnitTests OSX */,
+				46A8AD011CDF08E8009AFA26 /* libStandardPaths */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		46A8ACC11CDF0500009AFA26 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		46A8ACCB1CDF0500009AFA26 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		46A8ACE01CDF0522009AFA26 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		46A8ACE91CDF0522009AFA26 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		46A8ACBE1CDF0500009AFA26 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				46A8ACFC1CDF079A009AFA26 /* StandardPaths.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		46A8ACC91CDF0500009AFA26 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				46A8ACD31CDF0500009AFA26 /* StandardPathsTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		46A8ACDD1CDF0522009AFA26 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				46A8ACFD1CDF079A009AFA26 /* StandardPaths.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		46A8ACE71CDF0522009AFA26 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				46A8ACF91CDF063D009AFA26 /* StandardPathsTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		46A8ACFE1CDF08E8009AFA26 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				46A8AD0B1CDF09AA009AFA26 /* StandardPaths.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		46A8ACD01CDF0500009AFA26 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 46A8ACC21CDF0500009AFA26 /* StandardPaths */;
+			targetProxy = 46A8ACCF1CDF0500009AFA26 /* PBXContainerItemProxy */;
+		};
+		46A8ACEE1CDF0522009AFA26 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 46A8ACE11CDF0522009AFA26 /* StandardPaths OSX */;
+			targetProxy = 46A8ACED1CDF0522009AFA26 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		46A8ACD51CDF0500009AFA26 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_ASSIGN_ENUM = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
+				GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = YES;
+				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				GCC_WARN_PEDANTIC = YES;
+				GCC_WARN_SIGN_COMPARE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNKNOWN_PRAGMAS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				RUN_CLANG_STATIC_ANALYZER = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		46A8ACD61CDF0500009AFA26 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_ASSIGN_ENUM = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
+				GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = YES;
+				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				GCC_WARN_PEDANTIC = YES;
+				GCC_WARN_SIGN_COMPARE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNKNOWN_PRAGMAS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				RUN_CLANG_STATIC_ANALYZER = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		46A8ACD81CDF0500009AFA26 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.charcoaldesign.StandardPaths;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SKIP_INSTALL = YES;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		46A8ACD91CDF0500009AFA26 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.charcoaldesign.StandardPaths;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SKIP_INSTALL = YES;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		46A8ACDB1CDF0500009AFA26 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = UnitTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.charcoaldesign.StandardPathsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		46A8ACDC1CDF0500009AFA26 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = UnitTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.charcoaldesign.StandardPathsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		46A8ACF41CDF0522009AFA26 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.charcoaldesign.StandardPaths;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		46A8ACF51CDF0522009AFA26 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.charcoaldesign.StandardPaths;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		46A8ACF71CDF0522009AFA26 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = UnitTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "uk.co.charcoaldesign.StandardPaths-OSXTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		46A8ACF81CDF0522009AFA26 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = UnitTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "uk.co.charcoaldesign.StandardPaths-OSXTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		46A8AD091CDF08E9009AFA26 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		46A8AD0A1CDF08E9009AFA26 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		46A8ACBD1CDF0500009AFA26 /* Build configuration list for PBXProject "StandardPaths" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				46A8ACD51CDF0500009AFA26 /* Debug */,
+				46A8ACD61CDF0500009AFA26 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		46A8ACD71CDF0500009AFA26 /* Build configuration list for PBXNativeTarget "StandardPaths" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				46A8ACD81CDF0500009AFA26 /* Debug */,
+				46A8ACD91CDF0500009AFA26 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		46A8ACDA1CDF0500009AFA26 /* Build configuration list for PBXNativeTarget "UnitTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				46A8ACDB1CDF0500009AFA26 /* Debug */,
+				46A8ACDC1CDF0500009AFA26 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		46A8ACF31CDF0522009AFA26 /* Build configuration list for PBXNativeTarget "StandardPaths OSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				46A8ACF41CDF0522009AFA26 /* Debug */,
+				46A8ACF51CDF0522009AFA26 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		46A8ACF61CDF0522009AFA26 /* Build configuration list for PBXNativeTarget "UnitTests OSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				46A8ACF71CDF0522009AFA26 /* Debug */,
+				46A8ACF81CDF0522009AFA26 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		46A8AD081CDF08E9009AFA26 /* Build configuration list for PBXNativeTarget "libStandardPaths" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				46A8AD091CDF08E9009AFA26 /* Debug */,
+				46A8AD0A1CDF08E9009AFA26 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 46A8ACBA1CDF0500009AFA26 /* Project object */;
+}

--- a/StandardPaths.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/StandardPaths.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:StandardPaths.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/StandardPaths.xcodeproj/xcshareddata/xcschemes/StandardPaths OSX.xcscheme
+++ b/StandardPaths.xcodeproj/xcshareddata/xcschemes/StandardPaths OSX.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "46A8ACE11CDF0522009AFA26"
+               BuildableName = "StandardPaths.framework"
+               BlueprintName = "StandardPaths OSX"
+               ReferencedContainer = "container:StandardPaths.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "46A8ACEA1CDF0522009AFA26"
+               BuildableName = "UnitTests OSX.xctest"
+               BlueprintName = "UnitTests OSX"
+               ReferencedContainer = "container:StandardPaths.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "46A8ACE11CDF0522009AFA26"
+            BuildableName = "StandardPaths.framework"
+            BlueprintName = "StandardPaths OSX"
+            ReferencedContainer = "container:StandardPaths.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "46A8ACE11CDF0522009AFA26"
+            BuildableName = "StandardPaths.framework"
+            BlueprintName = "StandardPaths OSX"
+            ReferencedContainer = "container:StandardPaths.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "46A8ACE11CDF0522009AFA26"
+            BuildableName = "StandardPaths.framework"
+            BlueprintName = "StandardPaths OSX"
+            ReferencedContainer = "container:StandardPaths.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/StandardPaths.xcodeproj/xcshareddata/xcschemes/StandardPaths.xcscheme
+++ b/StandardPaths.xcodeproj/xcshareddata/xcschemes/StandardPaths.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "46A8ACC21CDF0500009AFA26"
+               BuildableName = "StandardPaths.framework"
+               BlueprintName = "StandardPaths"
+               ReferencedContainer = "container:StandardPaths.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "46A8ACCC1CDF0500009AFA26"
+               BuildableName = "UnitTests.xctest"
+               BlueprintName = "UnitTests"
+               ReferencedContainer = "container:StandardPaths.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "46A8ACC21CDF0500009AFA26"
+            BuildableName = "StandardPaths.framework"
+            BlueprintName = "StandardPaths"
+            ReferencedContainer = "container:StandardPaths.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "46A8ACC21CDF0500009AFA26"
+            BuildableName = "StandardPaths.framework"
+            BlueprintName = "StandardPaths"
+            ReferencedContainer = "container:StandardPaths.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "46A8ACC21CDF0500009AFA26"
+            BuildableName = "StandardPaths.framework"
+            BlueprintName = "StandardPaths"
+            ReferencedContainer = "container:StandardPaths.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/StandardPaths.xcodeproj/xcshareddata/xcschemes/libStandardPaths.xcscheme
+++ b/StandardPaths.xcodeproj/xcshareddata/xcschemes/libStandardPaths.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "46A8AD011CDF08E8009AFA26"
+               BuildableName = "libStandardPaths.a"
+               BlueprintName = "libStandardPaths"
+               ReferencedContainer = "container:StandardPaths.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "46A8AD011CDF08E8009AFA26"
+            BuildableName = "libStandardPaths.a"
+            BlueprintName = "libStandardPaths"
+            ReferencedContainer = "container:StandardPaths.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "46A8AD011CDF08E8009AFA26"
+            BuildableName = "libStandardPaths.a"
+            BlueprintName = "libStandardPaths"
+            ReferencedContainer = "container:StandardPaths.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/StandardPaths/StandardPaths.h
+++ b/StandardPaths/StandardPaths.h
@@ -35,6 +35,8 @@
 #import <Availability.h>
 #ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
 #import <UIKit/UIKit.h>
+#else
+#import <AppKit/AppKit.h>
 #endif
 
 

--- a/StandardPaths/StandardPaths.h
+++ b/StandardPaths/StandardPaths.h
@@ -39,6 +39,11 @@
 #import <AppKit/AppKit.h>
 #endif
 
+//! Project version number for StandardPaths.
+FOUNDATION_EXPORT double StandardPathsVersionNumber;
+
+//! Project version string for StandardPaths.
+FOUNDATION_EXPORT const unsigned char StandardPathsVersionString[];
 
 #ifndef SP_SWIZZLE_ENABLED
 #define SP_SWIZZLE_ENABLED 1

--- a/UnitTests/Info.plist
+++ b/UnitTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/UnitTests/StandardPathsTests.m
+++ b/UnitTests/StandardPathsTests.m
@@ -1,0 +1,39 @@
+//
+//  StandardPathsTests.m
+//  StandardPathsTests
+//
+//  Created by Ashton Williams on 8/05/2016.
+//  Copyright © 2016 Charcoal Design. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+@interface StandardPathsTests : XCTestCase
+
+@end
+
+@implementation StandardPathsTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end


### PR DESCRIPTION
Includes 3 schemes: an iOS framework, an OSX framework, and an iOS static library.

The iOS framework has a deployment target of iOS 8 since that is when dynamic frameworks support starts, the static library target was added with the minimum iOS target selectable in Xcode which is iOS 6.

Header was updated to include `AppKit` because it couldn't compile without it, I think it should be there anyway. externed  `StandardPathsVersionNumber` and `StandardPathsVersionString` were merged in from the Xcode generated framework header (do people use these?).

As you can see from the included travis config, this enables Carthage support too.