### PR TITLE
Add default return value to a non-void function

### DIFF
--- a/StandardPaths/StandardPaths.m
+++ b/StandardPaths/StandardPaths.m
@@ -82,6 +82,8 @@ static NSString *SPSuffixForUserInterfaceIdiom(UIUserInterfaceIdiom idiom)
             return SPDesktopSuffix;
         case UIUserInterfaceIdiomUnspecified:
             return nil;
+        default:
+            return nil;
     }
 }
 


### PR DESCRIPTION
Xcode 12 throws "Non-void function does not return a value in all control paths" error when building a project that uses StandardPaths.

This commit will fix the issue for Xcdoe 12.